### PR TITLE
Remove Pagination

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -12,6 +12,7 @@ listing:
       author: 'Author(s)'
     sort: 'categories'
     sort-ui: [categories, title, author]
+    page-size: 40
   - id: poster
     type: table
     categories: true


### PR DESCRIPTION
# Pull request

## Proposed changes

* display all papers on one listing page by removing pagination (which is the default setting for listings with more than 25 entries)

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have mentioned all co-authors in the PR description as `Co-authored-by: Name <email@domain.com>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for pagination, allowing users to specify the number of items displayed per page, enhancing control over listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->